### PR TITLE
fix: [user] 회원 정보 상세 조회 시 주문 목록에 주문 상태 추가

### DIFF
--- a/user-service/src/main/java/com/example/userservice/dto/response/OrderResponse.java
+++ b/user-service/src/main/java/com/example/userservice/dto/response/OrderResponse.java
@@ -18,4 +18,6 @@ public class OrderResponse {
     private LocalDateTime createdAt;
 
     private String orderId;
+
+    private String orderStatus;
 }


### PR DESCRIPTION
# 이슈
#35 

# 변경 내용
- 회원 정보 상세 조회 시 주문 목록에 주문 상태 데이터도 조회하도록 변경

# 기타
