### PR TITLE
feat: [Order] productId를 Product의 기본키인 Long형으로 변경

### DIFF
--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.h2database:h2'
 }
 
 dependencyManagement {

--- a/order-service/src/main/java/com/example/orderservice/client/ProductServiceClient.java
+++ b/order-service/src/main/java/com/example/orderservice/client/ProductServiceClient.java
@@ -8,5 +8,5 @@ import org.springframework.web.bind.annotation.PathVariable;
 public interface ProductServiceClient {
 
     @GetMapping("/products/{productId}/stock")
-    Integer getProductStock(@PathVariable String productId);
+    Integer getProductStock(@PathVariable Long productId);
 }

--- a/order-service/src/main/java/com/example/orderservice/domain/Order.java
+++ b/order-service/src/main/java/com/example/orderservice/domain/Order.java
@@ -21,7 +21,7 @@ public class Order extends BaseEntity {
     private Long id;
 
     @NotNull
-    private String productId;
+    private Long productId;
 
     @NotNull
     private int quantity;
@@ -43,7 +43,7 @@ public class Order extends BaseEntity {
     private OrderStatus orderStatus;
 
     @Builder
-    public Order(String productId, int quantity, int unitPrice, int totalPrice, String userId,
+    public Order(Long productId, int quantity, int unitPrice, int totalPrice, String userId,
                  String orderId, OrderStatus orderStatus) {
         this.productId = productId;
         this.quantity = quantity;

--- a/order-service/src/main/java/com/example/orderservice/dto/request/OrderCreateRequest.java
+++ b/order-service/src/main/java/com/example/orderservice/dto/request/OrderCreateRequest.java
@@ -8,8 +8,8 @@ import lombok.Getter;
 @Getter
 public class OrderCreateRequest {
 
-    @NotBlank(message = "상품 정보가 없습니다.")
-    private String productId;
+    @NotNull(message = "상품 정보가 없습니다.")
+    private Long productId;
 
     @NotNull(message = "수량을 선택하세요.")
     private int quantity;
@@ -21,7 +21,7 @@ public class OrderCreateRequest {
     private String userId;
 
     @Builder
-    public OrderCreateRequest(String productId, int quantity, int unitPrice, String userId) {
+    public OrderCreateRequest(Long productId, int quantity, int unitPrice, String userId) {
         this.productId = productId;
         this.quantity = quantity;
         this.unitPrice = unitPrice;

--- a/order-service/src/test/java/com/example/orderservice/service/OrderServiceTest.java
+++ b/order-service/src/test/java/com/example/orderservice/service/OrderServiceTest.java
@@ -11,35 +11,35 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@SpringBootTest
-class OrderServiceTest {
-
-    @Autowired
-    private OrderService orderService;
-
-    @Autowired
-    private OrderRepository orderRepository;
-
-    @Test
-    void 주문_전체_조회() throws Exception {
-        // given
-
-        // when
-        List<OrderListResponse> orderList = orderService.getAllOrder();
-
-        // then
-        assertEquals(OrderStatus.PAYMENT_COMPLETED.getValue(), orderList.get(0).getOrderStatus());
-    }
-
-    @Test
-    void 아이디로_주문_조회() throws Exception {
-        // given
-        String userId = "misun";
-
-        // when
-        List<OrderListResponse> orderList = orderService.getOrdersByUserId(userId);
-
-        // then
-        assertEquals(OrderStatus.PAYMENT_COMPLETED.getValue(), orderList.get(0).getOrderStatus());
-    }
-}
+//@SpringBootTest
+//class OrderServiceTest {
+//
+//    @Autowired
+//    private OrderService orderService;
+//
+//    @Autowired
+//    private OrderRepository orderRepository;
+//
+//    @Test
+//    void 주문_전체_조회() throws Exception {
+//        // given
+//
+//        // when
+//        List<OrderListResponse> orderList = orderService.getAllOrder();
+//
+//        // then
+//        assertEquals(OrderStatus.PAYMENT_COMPLETED.getValue(), orderList.get(0).getOrderStatus());
+//    }
+//
+//    @Test
+//    void 아이디로_주문_조회() throws Exception {
+//        // given
+//        String userId = "misun";
+//
+//        // when
+//        List<OrderListResponse> orderList = orderService.getOrdersByUserId(userId);
+//
+//        // then
+//        assertEquals(OrderStatus.PAYMENT_COMPLETED.getValue(), orderList.get(0).getOrderStatus());
+//    }
+//}

--- a/order-service/src/test/java/com/example/orderservice/service/OrderServiceTest.java
+++ b/order-service/src/test/java/com/example/orderservice/service/OrderServiceTest.java
@@ -1,45 +1,100 @@
 package com.example.orderservice.service;
 
+import com.example.orderservice.domain.Order;
 import com.example.orderservice.dto.response.OrderListResponse;
 import com.example.orderservice.enumeration.OrderStatus;
 import com.example.orderservice.repository.OrderRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-//@SpringBootTest
-//class OrderServiceTest {
-//
-//    @Autowired
-//    private OrderService orderService;
-//
-//    @Autowired
-//    private OrderRepository orderRepository;
-//
-//    @Test
-//    void 주문_전체_조회() throws Exception {
-//        // given
-//
-//        // when
-//        List<OrderListResponse> orderList = orderService.getAllOrder();
-//
-//        // then
-//        assertEquals(OrderStatus.PAYMENT_COMPLETED.getValue(), orderList.get(0).getOrderStatus());
-//    }
-//
-//    @Test
-//    void 아이디로_주문_조회() throws Exception {
-//        // given
-//        String userId = "misun";
-//
-//        // when
-//        List<OrderListResponse> orderList = orderService.getOrdersByUserId(userId);
-//
-//        // then
-//        assertEquals(OrderStatus.PAYMENT_COMPLETED.getValue(), orderList.get(0).getOrderStatus());
-//    }
-//}
+@SpringBootTest
+@Transactional
+class OrderServiceTest {
+
+    @Autowired
+    private OrderService orderService;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    private final String testOrderId = UUID.randomUUID().toString();
+
+    @BeforeEach
+    void setUp() {
+        Order order = Order.builder()
+                .productId(1L)
+                .quantity(10)
+                .unitPrice(10000)
+                .totalPrice(100000)
+                .userId("testuser")
+                .orderId(testOrderId)
+                .orderStatus(OrderStatus.PAYMENT_COMPLETED)
+                .build();
+
+        Order order2 = Order.builder()
+                .productId(2L)
+                .quantity(2)
+                .unitPrice(5000)
+                .totalPrice(10000)
+                .userId("happy")
+                .orderId(UUID.randomUUID().toString())
+                .orderStatus(OrderStatus.PAYMENT_COMPLETED)
+                .build();
+
+        orderRepository.save(order);
+        orderRepository.save(order2);
+    }
+
+    @Test
+    void 주문_전체_조회() throws Exception {
+        // given
+
+        // when
+        List<OrderListResponse> orderList = orderService.getAllOrder();
+        int orderSize = orderRepository.findAll().size();
+
+        // then
+        assertEquals("1", orderList.get(0).getProductId().toString());
+        assertEquals(10, orderList.get(0).getQuantity());
+        assertEquals(10000, orderList.get(0).getUnitPrice());
+        assertEquals(testOrderId, orderList.get(0).getOrderId());
+        assertEquals(OrderStatus.PAYMENT_COMPLETED.getValue(), orderList.get(0).getOrderStatus());
+        assertEquals(2, orderSize);
+    }
+
+    @Test
+    void 아이디로_주문_조회() throws Exception {
+        // given
+        String userId = "testuser";
+
+        // when
+        List<OrderListResponse> orderList = orderService.getOrdersByUserId(userId);
+
+        // then
+        assertEquals("1", orderList.get(0).getProductId().toString());
+        assertEquals(10, orderList.get(0).getQuantity());
+        assertEquals(10000, orderList.get(0).getUnitPrice());
+        assertEquals(testOrderId, orderList.get(0).getOrderId());
+        assertEquals(OrderStatus.PAYMENT_COMPLETED.getValue(), orderList.get(0).getOrderStatus());
+    }
+
+    @Test
+    void 아이디로_주문_조회_실패_없는아이디() throws Exception {
+        // given
+        String userId = "noneId";
+
+        // when
+        List<OrderListResponse> orderList = orderService.getOrdersByUserId(userId);
+
+        // then
+        assertEquals(0, orderList.size());
+    }
+}


### PR DESCRIPTION
# 이슈
#47 

# 변경 내용
- productId를 String -> Long형으로 변경
- 테스트 db를 H2로 변경

# 기타
- 주문 생성 요청 시 unitPrice는 product-service에서 조회하여 값 비교하는 기능 추가 필요